### PR TITLE
Field values got cleared when form interactions have side effect causing rerender

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![moubi](https://img.shields.io/circleci/build/gh/moubi/enform?label=circleci&style=flat-square)](https://circleci.com/gh/moubi/swipeable-react)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/moubi/enform.svg?style=flat-square&logo=lgtm&logoWidth=15)](https://lgtm.com/projects/g/moubi/enform/context:javascript)
 [![moubi](https://img.shields.io/npm/v/enform?style=flat-square)](https://www.npmjs.com/package/enform)
-[![moubi](https://img.shields.io/static/v1?style=flat-square&label=gzip%20size&message=1.3%20kB&color=green)](#development)
+[![moubi](https://img.shields.io/static/v1?style=flat-square&label=gzip%20size&message=1.6%20kB&color=green)](#development)
 [![moubi](https://img.shields.io/github/license/moubi/enform?style=flat-square)](LICENSE)
 
 [Usage](docs/index.md#basic-form-field-and-a-button) • [Examples](docs/index.md#documentation) • [API](docs/index.md#api) • [Contribute](#contributing) • [License](LICENSE)
@@ -65,7 +65,7 @@ const App = () => (
 
 **View more intereactive [examples here](docs/index.md#documentation)**.
 
-This [⚠️ note on re-rendering](docs/index.md#%EF%B8%8F-note-on-re-rendering) may be useful in the scenario where default values in `initial` prop change between renders, but the actual object passed remain the same (by `ref`).
+This [⚠️ note on re-rendering](docs/index.md#%EF%B8%8F-note-on-re-rendering) gives answers to some common questions about auto updating field values based on changes in the `initial` prop.
 
 ## Install
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -769,9 +769,9 @@ The `<label />` element takes it's default text from the `initial` object and up
 ___
 
 ## ⚠️ Note on re-rendering
-It is important to note that `<Enform />` **will do its best to re-render when `initial` values change**. That is done by comparing the current and previous value of `initial` by ref.
+It is important to note that `<Enform />` **will do its best to re-render when `initial` values change**. That is done by comparing the current and previous `initial` values.
 
-Usage like this is **guaranteed** to work:
+Usage like this fx is **guaranteed** to work:
 ```jsx
 class ConsumerComponent extends Component {
   ...
@@ -788,7 +788,7 @@ class ConsumerComponent extends Component {
 }
 ```
 
-The following, though, may not work:
+Something like that should also work:
 ```jsx
 class ConsumerComponent extends Component {
   constructor(props) {
@@ -819,23 +819,14 @@ class ConsumerComponent extends Component {
   }
 }
 ```
-In this situation Enform won't update the `<input />` with `"Justing Case"` value. It will remain empty. **Why?** Simply because the same object by ref (`this.initial`) is passed to Enform causing it to think there are no changes for the default values.
+
+### Using Javascript `Set` and `Map` as values
+This is considered more as an edge case and may cause issues in some cases. Fx. Enform uses sorting and `stringification` to compare `initial` values, but `JSON.stringify` doesn't transform `Set` and `Map` structures correctly. It may lead to the state not being updated correctly.
+
+Ensure these values are transformed to an `Object` or `Array` before passing down.
 
 ### What is the solution?
-**First** possible one is to recreate the `initial` prop object on each render:
-```jsx
-render() {
-  {/* Construct a new object out of this.initial */}
-  <Enform initial={{ ...this.initial }}>
-    {props => (
-      {/* input will render "Justin Case" */}
-      <input value={props.values.name} />
-    )}
-  </Enform>
-}
-```
-
-**Second** [recommended technique](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) would be to use the special `key` prop forcing that way Enform to update. Let's see the changes in the `render()` method:
+[Recommended technique](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) would be to use the special `key` prop forcing that way Enform to update. Let's see the changes in the `render()` method:
 
 ```jsx
 render() {


### PR DESCRIPTION
If interacting with the form has side effects in the parent (like setting the state) that will cause rerender it may in some cases revert field values to the last `initial`. **This is because comparison by ref is not enough to catch changes in the initial prop between renders** 
Test is added to prove that use case.

To fix that and avoid deep comparison with external libraries an approach was chosen which combines `JSON.stringify` and `sorting` giving high chance of success.