### PR TITLE
Clear field error if it exists

### DIFF
--- a/src/Enform.js
+++ b/src/Enform.js
@@ -108,10 +108,12 @@ export default function Enform({ initial, validation, children }) {
       ...values,
       [name]: value
     });
-    setErrors(prevErrors => ({
-      ...prevErrors,
-      [name]: false
-    }));
+    if (errors[name]) {
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        [name]: false
+      }));
+    }
   }
 
   return children({

--- a/src/Enform.js
+++ b/src/Enform.js
@@ -108,12 +108,7 @@ export default function Enform({ initial, validation, children }) {
       ...values,
       [name]: value
     });
-    if (errors[name]) {
-      setErrors(prevErrors => ({
-        ...prevErrors,
-        [name]: false
-      }));
-    }
+    errors[name] && clearError(name);
   }
 
   return children({


### PR DESCRIPTION
Calling `onChange` will clear existing errors if they really exist. If not, no set state should be performed. 

Closes #13 